### PR TITLE
Move to kelindar/bench

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.25"
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.prof
+*.test
+*.exe
+bench.gob
+bench.json

--- a/emit/event.go
+++ b/emit/event.go
@@ -66,7 +66,7 @@ func (e Timer) Type() uint32 {
 // On subscribes to an event, the type of the event will be automatically
 // inferred from the provided type. Must be constant for this to work.
 func On[T event.Event](handler func(event T, now time.Time, elapsed time.Duration) error) context.CancelFunc {
-	return event.Subscribe[signal[T]](event.Default, func(m signal[T]) {
+	return event.Subscribe(event.Default, func(m signal[T]) {
 		if err := handler(m.Data, m.Time, m.Elapsed); err != nil {
 			Error(err, m.Data)
 		}
@@ -75,7 +75,7 @@ func On[T event.Event](handler func(event T, now time.Time, elapsed time.Duratio
 
 // OnType subscribes to an event with the specified event type.
 func OnType[T event.Event](eventType uint32, handler func(event T, now time.Time, elapsed time.Duration) error) context.CancelFunc {
-	return event.SubscribeTo[signal[T]](event.Default, eventType, func(m signal[T]) {
+	return event.SubscribeTo(event.Default, eventType, func(m signal[T]) {
 		if err := handler(m.Data, m.Time, m.Elapsed); err != nil {
 			Error(err, m.Data)
 		}
@@ -84,7 +84,7 @@ func OnType[T event.Event](eventType uint32, handler func(event T, now time.Time
 
 // OnError subscribes to an error event.
 func OnError(handler func(err error, about any)) context.CancelFunc {
-	return event.Subscribe[fault](event.Default, func(m fault) {
+	return event.Subscribe(event.Default, func(m fault) {
 		handler(m.error, m.About)
 	})
 }
@@ -97,7 +97,7 @@ func OnEvery(handler func(now time.Time, elapsed time.Duration) error, interval 
 	}
 
 	// Subscribe to the timer event
-	cancel := OnType[Timer](id, func(_ Timer, now time.Time, elapsed time.Duration) error {
+	cancel := OnType(id, func(_ Timer, now time.Time, elapsed time.Duration) error {
 		return handler(now, elapsed)
 	})
 

--- a/example/bench/main.go
+++ b/example/bench/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/kelindar/bench"
+	"github.com/kelindar/timeline"
+	"github.com/kelindar/timeline/emit"
+)
+
+func main() {
+	bench.Run(benchmark,
+		bench.WithDuration(5*time.Millisecond),
+		bench.WithSamples(100),
+	)
+}
+
+func benchmark(b *bench.B) {
+	s := timeline.New()
+	var counter atomic.Uint64
+	const batch = 10
+
+	emit.On(func(event *ByPointer, now time.Time, elapsed time.Duration) error {
+		counter.Add(1)
+		return nil
+	})
+
+	emit.On(func(event ByValue, now time.Time, elapsed time.Duration) error {
+		counter.Add(1)
+		return nil
+	})
+
+	b.RunN("timeline-next", func(i int) int {
+		for i := 0; i < batch; i++ {
+			s.Run(func(now time.Time, elapsed time.Duration) bool {
+				counter.Add(1)
+				return true
+			})
+		}
+		s.Tick()
+		return batch
+	})
+
+	b.RunN("timeline-after", func(i int) int {
+		for i := 0; i < batch; i++ {
+			s.RunAfter(func(now time.Time, elapsed time.Duration) bool {
+				counter.Add(1)
+				return true
+			}, time.Duration(10*i)*time.Millisecond)
+		}
+		s.Tick()
+		return batch
+	})
+
+	b.RunN("emit-next-ptr", func(i int) int {
+		for i := 0; i < batch; i++ {
+			emit.Next(&ByPointer{Number: i, String: "test"})
+		}
+		s.Tick()
+		return batch
+	})
+
+	b.RunN("emit-after-ptr", func(i int) int {
+		for i := 0; i < batch; i++ {
+			emit.After(&ByPointer{Number: i, String: "test"}, time.Duration(10*i)*time.Millisecond)
+		}
+		s.Tick()
+		return batch
+	})
+
+	b.RunN("emit-next-val", func(i int) int {
+		for i := 0; i < batch; i++ {
+			emit.Next(ByValue{Number: i, String: "test"})
+		}
+		s.Tick()
+		return batch
+	})
+
+	b.RunN("emit-after-val", func(i int) int {
+		for i := 0; i < batch; i++ {
+			emit.After(ByValue{Number: i, String: "test"}, time.Duration(10*i)*time.Millisecond)
+		}
+		s.Tick()
+		return batch
+	})
+
+}
+
+type ByPointer struct {
+	Number int
+	String string
+}
+
+func (t *ByPointer) Type() uint32 {
+	return 0x01
+}
+
+type ByValue struct {
+	Number int
+	String string
+}
+
+func (t ByValue) Type() uint32 {
+	return 0x02
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/kelindar/timeline
 
-go 1.20
+go 1.24.0
 
 require (
+	github.com/kelindar/bench v0.2.0
 	github.com/kelindar/event v1.5.2
 	github.com/stretchr/testify v1.10.0
 )
@@ -10,5 +11,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gonum.org/v1/gonum v0.16.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,15 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kelindar/bench v0.2.0 h1:MyGBv+tVWplvAxPSUxPO9U1MFYTntwOV0GsS9LWrBKo=
+github.com/kelindar/bench v0.2.0/go.mod h1:OuvErDf7ALg/UW61ltcLoddriG/zPBPUX7QpIUhrqhQ=
 github.com/kelindar/event v1.5.2 h1:qtgssZqMh/QQMCIxlbx4wU3DoMHOrJXKdiZhphJ4YbY=
 github.com/kelindar/event v1.5.2/go.mod h1:UxWPQjWK8u0o9Z3ponm2mgREimM95hm26/M9z8F488Q=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
+gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/timeline.go
+++ b/timeline.go
@@ -37,12 +37,6 @@ type bucket struct {
 	queue []job
 }
 
-// run holds the context for executing a task
-type run struct {
-	task job
-	time time.Time
-}
-
 // Scheduler manages and executes scheduled tasks.
 type Scheduler struct {
 	next    atomic.Int64 // next tick

--- a/timeline_test.go
+++ b/timeline_test.go
@@ -15,50 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var counter atomic.Uint64
-
-/*
-cpu: 13th Gen Intel(R) Core(TM) i7-13700K
-BenchmarkRun/next-24         	11874015	       100.4 ns/op	        11.79 million/op	     117 B/op	       0 allocs/op
-BenchmarkRun/after-24        	   10000	    471016 ns/op	         0.9101 million/op	    1469 B/op	       0 allocs/op
-*/
-func BenchmarkRun(b *testing.B) {
-	work := func(time.Time, time.Duration) bool {
-		counter.Add(1)
-		return true
-	}
-
-	b.Run("next", func(b *testing.B) {
-		counter.Store(0)
-		s := New()
-		s.Start(context.Background())
-		b.ReportAllocs()
-		b.ResetTimer()
-
-		for n := 0; n < b.N; n++ {
-			s.Run(work)
-		}
-
-		b.ReportMetric(float64(counter.Load())/1000000, "million/op")
-	})
-
-	b.Run("after", func(b *testing.B) {
-		counter.Store(0)
-		s := New()
-		s.Start(context.Background())
-		b.ReportAllocs()
-		b.ResetTimer()
-
-		for n := 0; n < b.N; n++ {
-			for i := 0; i < 100; i++ {
-				s.RunAfter(work, time.Duration(10*i)*time.Millisecond)
-			}
-		}
-
-		b.ReportMetric(float64(counter.Load())/1000000, "million/op")
-	})
-}
-
 func TestRunAt(t *testing.T) {
 	now := time.Unix(0, 0)
 	log := make(Log, 0, 8)


### PR DESCRIPTION
This pull request introduces a new benchmarking example for the timeline package, updates dependencies, and simplifies event subscription signatures. The main focus is on providing a comprehensive benchmark for different event emission and scheduling strategies, while also modernizing and cleaning up the codebase.

**Benchmarking and Examples:**

* Added a new `example/bench/main.go` file that benchmarks various timeline and emit event patterns, including pointer/value types and different scheduling strategies. This serves as both documentation and a performance test suite.
* Removed the old `BenchmarkRun` from `timeline_test.go` to avoid redundancy, as benchmarking is now handled in the new example.

**API and Codebase Simplification:**

* Simplified event subscription functions in `emit/event.go` by removing explicit type parameters from `event.Subscribe` and `event.SubscribeTo` calls, making the API easier to use and read. [[1]](diffhunk://#diff-7a172352a7b2111dd1664e4d9814faed9cb99c62820ffbb2ff88ed51a30b5564L69-R69) [[2]](diffhunk://#diff-7a172352a7b2111dd1664e4d9814faed9cb99c62820ffbb2ff88ed51a30b5564L78-R78) [[3]](diffhunk://#diff-7a172352a7b2111dd1664e4d9814faed9cb99c62820ffbb2ff88ed51a30b5564L87-R87) [[4]](diffhunk://#diff-7a172352a7b2111dd1664e4d9814faed9cb99c62820ffbb2ff88ed51a30b5564L100-R100)
* Removed the unused `run` struct from `timeline.go` to clean up the codebase.