### PR TITLE
Pack scheduling to 64bit to make job 128 bit long

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -74,13 +74,6 @@ func (s sched) WithRunAt(runAt tick) sched {
 	return sched(newData)
 }
 
-// WithInterval creates a new scheduleData with updated interval
-func (s sched) WithInterval(interval span) sched {
-	newData := uint64(s) & ^uint64(intervalMask) // Clear interval bits
-	newData |= uint64(interval) & intervalMask
-	return sched(newData)
-}
-
 // bucket represents a bucket for a particular window of the second.
 type bucket struct {
 	mu    sync.Mutex
@@ -202,7 +195,7 @@ func (s *Scheduler) Tick() time.Time {
 		switch {
 		case repeat && s.bucketOf(nextTick) == s.bucketOf(tickNow):
 			bucket.mu.Lock()
-			task.sched = task.sched.WithInterval(span(nextTick - tickNow)).WithRunAt(nextTick)
+			task.sched = task.sched.WithRunAt(nextTick)
 			bucket.queue = append(bucket.queue, task)
 			bucket.mu.Unlock()
 		case repeat: // different bucket

--- a/timeline.go
+++ b/timeline.go
@@ -11,9 +11,14 @@ import (
 )
 
 const (
-	resolution = 10 * time.Millisecond
-	numBuckets = int(1 * time.Second / resolution)
-	maxJobs    = 1e5 // ~ 10M ev/s
+	resolution   = 10 * time.Millisecond
+	numBuckets   = int(1 * time.Second / resolution)
+	maxJobs      = 1e5 // ~ 10M ev/s
+	recurringBit = 63
+	runAtBits    = 39
+	intervalBits = 24
+	runAtMask    = uint64((1<<runAtBits - 1) << intervalBits) // 39 bits for runAt
+	intervalMask = uint64((1<<intervalBits - 1))              // 24 bits for interval
 )
 
 // Task defines a scheduled function. 'now' is the execution time, and 'elapsed'
@@ -23,12 +28,57 @@ const (
 // interval. Returning 'false' implies that the task should not be executed again.
 type Task = func(now time.Time, elapsed time.Duration) bool
 
+// sched packs scheduling information into a 64-bit integer:
+// - Bit 63: recurring flag (1 = recurring, 0 = one-time)
+// - Bits 62-24: runAt time in ticks (39 bits)
+// - Bits 23-0: interval in ticks (24 bits)
+type sched uint64
+
 // job represents a scheduled task.
 type job struct {
 	Task
-	RunAt tick // When the task should run
-	Since span // Elapsed ticks between scheduled time and starting time
-	Every span // (optional) In ticks, how often the task should run (0 = once)
+	sched
+}
+
+// newSched creates a new packed scheduling data with the given values
+func newSched(runAt tick, interval span, recurring bool) sched {
+	var data uint64
+	if recurring {
+		data |= 1 << recurringBit
+	}
+
+	data |= uint64(runAt) << intervalBits & runAtMask
+	data |= uint64(interval) & intervalMask
+	return sched(data)
+}
+
+// RunAt returns the tick when the task should run
+func (s sched) RunAt() tick {
+	return tick((uint64(s) & runAtMask) >> intervalBits)
+}
+
+// Interval returns the interval in ticks
+func (s sched) Interval() span {
+	return span(uint64(s) & intervalMask)
+}
+
+// Recurring returns whether this task should repeat
+func (s sched) Recurring() bool {
+	return (uint64(s)>>recurringBit)&1 == 1
+}
+
+// WithRunAt creates a new scheduleData with updated runAt time
+func (s sched) WithRunAt(runAt tick) sched {
+	newData := uint64(s) & ^uint64(runAtMask) // Clear runAt bits
+	newData |= uint64(runAt) << intervalBits & runAtMask
+	return sched(newData)
+}
+
+// WithInterval creates a new scheduleData with updated interval
+func (s sched) WithInterval(interval span) sched {
+	newData := uint64(s) & ^uint64(intervalMask) // Clear interval bits
+	newData |= uint64(interval) & intervalMask
+	return sched(newData)
 }
 
 // bucket represents a bucket for a particular window of the second.
@@ -49,7 +99,7 @@ type Scheduler struct {
 func New() *Scheduler {
 	s := &Scheduler{
 		buckets: make([]*bucket, numBuckets),
-		pending: make([]job, 0, 64), // pre-allocate execution buffer
+		pending: make([]job, 0, 256), // pre-allocate execution buffer
 	}
 
 	for i := 0; i < numBuckets; i++ {
@@ -97,17 +147,20 @@ func (s *Scheduler) schedule(event Task, when tick, repeat span) {
 		time.Sleep(500 * time.Microsecond)
 	}
 
+	recurring := repeat > 0
+	if repeat == 0 {
+		repeat = span(when - s.now())
+	}
+
 	s.enqueueJob(job{
 		Task:  event,
-		RunAt: when,
-		Since: span(when - s.now()),
-		Every: repeat,
+		sched: newSched(when, repeat, recurring),
 	})
 }
 
 // enqueueJob adds a job to the queue. If the queue is full, it will wait briefly.
 func (s *Scheduler) enqueueJob(job job) {
-	bucket := s.bucketOf(job.RunAt)
+	bucket := s.bucketOf(job.RunAt())
 	bucket.mu.Lock()
 	bucket.queue = append(bucket.queue, job)
 	bucket.mu.Unlock()
@@ -130,7 +183,7 @@ func (s *Scheduler) Tick() time.Time {
 	s.pending = s.pending[:0] // reuse buffer
 	for _, task := range bucket.queue {
 		switch {
-		case task.RunAt > tickNow:
+		case task.RunAt() > tickNow:
 			bucket.queue[offset] = task
 			offset++
 		default:
@@ -142,14 +195,14 @@ func (s *Scheduler) Tick() time.Time {
 
 	// Execute tasks (without lock to prevent deadlock)
 	for _, task := range s.pending {
-		repeat := task.Task(timeNow, task.Since.Duration()) && task.Every != 0
-		nextTick := tickNow + tick(task.Every)
+		shouldContinue := task.Task(timeNow, task.Interval().Duration())
+		repeat := shouldContinue && task.Recurring()
+		nextTick := tickNow + tick(task.Interval())
 
 		switch {
 		case repeat && s.bucketOf(nextTick) == s.bucketOf(tickNow):
 			bucket.mu.Lock()
-			task.Since = span(nextTick - tickNow)
-			task.RunAt = nextTick
+			task.sched = task.sched.WithInterval(span(nextTick - tickNow)).WithRunAt(nextTick)
 			bucket.queue = append(bucket.queue, task)
 			bucket.mu.Unlock()
 		case repeat: // different bucket
@@ -157,9 +210,7 @@ func (s *Scheduler) Tick() time.Time {
 			bucket.mu.Lock()
 			bucket.queue = append(bucket.queue, job{
 				Task:  task.Task,
-				RunAt: nextTick,
-				Since: task.Every,
-				Every: task.Every,
+				sched: newSched(nextTick, task.Interval(), true),
 			})
 			bucket.mu.Unlock()
 		default:

--- a/timeline.go
+++ b/timeline.go
@@ -67,13 +67,6 @@ func (s sched) Recurring() bool {
 	return (uint64(s)>>recurringBit)&1 == 1
 }
 
-// WithRunAt creates a new scheduleData with updated runAt time
-func (s sched) WithRunAt(runAt tick) sched {
-	newData := uint64(s) & ^uint64(runAtMask) // Clear runAt bits
-	newData |= uint64(runAt) << intervalBits & runAtMask
-	return sched(newData)
-}
-
 // bucket represents a bucket for a particular window of the second.
 type bucket struct {
 	mu    sync.Mutex
@@ -195,7 +188,6 @@ func (s *Scheduler) Tick() time.Time {
 		switch {
 		case repeat && s.bucketOf(nextTick) == s.bucketOf(tickNow):
 			bucket.mu.Lock()
-			task.sched = task.sched.WithRunAt(nextTick)
 			bucket.queue = append(bucket.queue, task)
 			bucket.mu.Unlock()
 		case repeat: // different bucket

--- a/timeline_test.go
+++ b/timeline_test.go
@@ -183,7 +183,7 @@ func TestStart(t *testing.T) {
 
 func TestJobSize(t *testing.T) {
 	size := unsafe.Sizeof(job{})
-	assert.Equal(t, 24, int(size))
+	assert.Equal(t, 16, int(size))
 }
 
 func TestRunDuringTickDeadlocks(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the way scheduling information is stored and managed in the `timeline.go` scheduler. It introduces a compact, bit-packed representation for scheduling metadata, reducing memory usage and simplifying job state management. The most important changes are grouped below:

### Scheduler data structure improvements

* Introduced a new `sched` type that packs recurring flag, runAt time, and interval into a single 64-bit integer, replacing separate fields in the `job` struct. Helper methods for extracting and updating each field were added (`timeline.go`). [[1]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00R17-R21) [[2]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00R31-R81)
* Refactored the `job` struct to use the new `sched` type, and updated all related logic to use the new accessors and constructors (`timeline.go`). [[1]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00R31-R81) [[2]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00R150-R163) [[3]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00L133-R186) [[4]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00L145-R213)

### Performance and memory optimizations

* Increased the pre-allocated size of the `pending` job buffer in the `Scheduler` from 64 to 256, which can help reduce allocations under load (`timeline.go`).
* Reduced the memory footprint of the `job` struct, as verified by the updated test in `timeline_test.go` (from 24 bytes to 16 bytes) (`timeline_test.go`).

### Scheduling logic adjustments

* Updated scheduling and rescheduling logic to use the new packed representation, including correct handling for recurring and one-time tasks, and proper propagation of interval and runAt values (`timeline.go`). [[1]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00R150-R163) [[2]](diffhunk://#diff-bfc529be68bab9d53027157f238a651bb9f39eab02892776d1a168e1448ccf00L145-R213)